### PR TITLE
make custom category page show the 404 page for nonexistent categories

### DIFF
--- a/src/views/CustomCategoryPage.vue
+++ b/src/views/CustomCategoryPage.vue
@@ -136,6 +136,18 @@
     },
     created() {
       this.categoryName = this.$route.params['name'];
+
+      // make sure the url-supplied category name is a real category
+      const customCategoryNames = LocalStorage.getCustomCategoryNames();
+      if (!customCategoryNames.includes(this.categoryName)) {
+        // replace the current page with the 404 page defined in the router, and don't change the url
+        // this makes it clear to the user what the invalid route is, and keeps the browser back button working right
+        // https://stackoverflow.com/a/68877623
+        this.$router.replace({
+          name: '404',
+          params: { 0: this.$route.path },
+        });
+      }
     },
     methods: {
       loadWords() {


### PR DESCRIPTION
This fixes this issue: https://trello.com/c/l9I5kXwE

Currently, nonexistent custom categories render successfully, appearing like an empty category and throwing an unhandled error:

![image](https://github.com/project-qwerty/project-qwerty/assets/4065127/27db33ee-c742-43e4-a2a4-252be6722908)

Now, they show the 404 page:

![image](https://github.com/project-qwerty/project-qwerty/assets/4065127/086a0065-0ac0-45c0-8e26-6d1a1d3653b7)
